### PR TITLE
feat: caCerts

### DIFF
--- a/charts/packmind/Chart.yaml
+++ b/charts/packmind/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: packmind
 type: application
-version: 1.3.1
+version: 1.4.0
 appVersion: 1.3.1
 description: Elevate developers and code with Packmind
 home: https://github.com/packmindhub/packmind-helm-chart

--- a/charts/packmind/templates/deployment.yaml
+++ b/charts/packmind/templates/deployment.yaml
@@ -123,11 +123,11 @@ spec:
           ports:
             - containerPort: 3000
           livenessProbe:
-           httpGet:
-             path: /open/healthcheck/ping
-             port: 3000
-           initialDelaySeconds: 30
-           periodSeconds: 30
+            httpGet:
+              path: /open/healthcheck/ping
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
           {{- if .Values.app.caCerts.enabled }}
           volumeMounts:
             - name: ca-certs
@@ -245,11 +245,11 @@ spec:
           ports:
             - containerPort: 3000
           livenessProbe:
-           httpGet:
-             path: /open/healthcheck/ping
-             port: 3000
-           initialDelaySeconds: 30
-           periodSeconds: 30
+            httpGet:
+              path: /open/healthcheck/ping
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
           {{- if .Values.app.caCerts.enabled }}
           volumeMounts:
             - name: ca-certs

--- a/charts/packmind/templates/deployment.yaml
+++ b/charts/packmind/templates/deployment.yaml
@@ -128,6 +128,12 @@ spec:
              port: 3000
            initialDelaySeconds: 30
            periodSeconds: 30
+          {{- if .Values.app.caCerts.enabled }}
+          volumeMounts:
+            - name: ca-certs
+              mountPath: /ca-certs
+              readOnly: true
+          {{- end }}
           env:
             - name: REDIS_HOST
               value: "packmind-redis"
@@ -158,6 +164,10 @@ spec:
                   name: {{ $value.secretName }}
                   key: {{ $value.secretKey }}
             {{- end }}
+            {{- if .Values.app.caCerts.enabled }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: /ca-certs/{{ .Values.caCerts.secret.key }}
+            {{- end }}
       {{- if and .Values.app.images.secret .Values.app.images.secret.name }}
       imagePullSecrets:
         - name: {{ .Values.app.images.secret.name }}
@@ -173,6 +183,12 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.app.caCerts.enabled }}
+      volumes:
+        - name: ca-certs
+          secret: 
+            secretName: {{ .Values.caCerts.secret.name}}
       {{- end }}
 ---
 apiVersion: apps/v1

--- a/charts/packmind/templates/deployment.yaml
+++ b/charts/packmind/templates/deployment.yaml
@@ -166,7 +166,7 @@ spec:
             {{- end }}
             {{- if .Values.app.caCerts.enabled }}
             - name: NODE_EXTRA_CA_CERTS
-              value: /ca-certs/{{ .Values.caCerts.secret.key }}
+              value: /ca-certs/{{ .Values.app.caCerts.secret.key }}
             {{- end }}
       {{- if and .Values.app.images.secret .Values.app.images.secret.name }}
       imagePullSecrets:
@@ -188,7 +188,7 @@ spec:
       volumes:
         - name: ca-certs
           secret: 
-            secretName: {{ .Values.caCerts.secret.name}}
+            secretName: {{ .Values.app.caCerts.secret.name}}
       {{- end }}
 ---
 apiVersion: apps/v1

--- a/charts/packmind/templates/deployment.yaml
+++ b/charts/packmind/templates/deployment.yaml
@@ -250,6 +250,12 @@ spec:
              port: 3000
            initialDelaySeconds: 30
            periodSeconds: 30
+          {{- if .Values.app.caCerts.enabled }}
+          volumeMounts:
+            - name: ca-certs
+              mountPath: /ca-certs
+              readOnly: true
+          {{- end }}
           env:
             - name: REDIS_HOST
               value: "packmind-redis"
@@ -278,6 +284,10 @@ spec:
                   name: {{ $value.secretName }}
                   key: {{ $value.secretKey }}
             {{- end }}
+            {{- if .Values.app.caCerts.enabled }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: /ca-certs/{{ .Values.app.caCerts.secret.key }}
+            {{- end }}
       {{- if and .Values.app.images.secret .Values.app.images.secret.name }}
       imagePullSecrets:
         - name: {{ .Values.app.images.secret.name }}
@@ -293,6 +303,12 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.app.caCerts.enabled }}
+      volumes:
+        - name: ca-certs
+          secret: 
+            secretName: {{ .Values.app.caCerts.secret.name}}
       {{- end }}
 ---
 apiVersion: apps/v1
@@ -348,6 +364,12 @@ spec:
               port: 3000
             initialDelaySeconds: 30
             periodSeconds: 30
+          {{- if .Values.app.caCerts.enabled }}
+          volumeMounts:
+            - name: ca-certs
+              mountPath: /ca-certs
+              readOnly: true
+          {{- end }}
           env:
             - name: SERVER_PORT
               value: "3000"
@@ -376,6 +398,10 @@ spec:
                   name: {{ $value.secretName }}
                   key: {{ $value.secretKey }}
             {{- end }}
+            {{- if .Values.app.caCerts.enabled }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: /ca-certs/{{ .Values.app.caCerts.secret.key }}
+            {{- end }}
       {{- if and .Values.app.images.secret .Values.app.images.secret.name }}
       imagePullSecrets:
         - name: {{ .Values.app.images.secret.name }}
@@ -391,6 +417,12 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.app.caCerts.enabled }}
+      volumes:
+        - name: ca-certs
+          secret: 
+            secretName: {{ .Values.app.caCerts.secret.name}}
       {{- end }}
 ---
 apiVersion: apps/v1

--- a/charts/packmind/values.yaml
+++ b/charts/packmind/values.yaml
@@ -51,6 +51,11 @@
   # - envVariable: THEMIS_AUTH_CONFIG_ADMIN_PASSWORD
   #   secretName: secret-openldap
   #   secretKey: openldap-password
+  caCerts: # add custom CA bundle to app container
+    enabled: false
+    # secret:
+    #   name: ca-certs
+    #   key: bundle.crt
   redis:
     pvc:
       enabled: false


### PR DESCRIPTION
Add caCerts parameter to allow use custom CA for private openai endpoint and svn